### PR TITLE
SONARTFVC-28 Update cache given a CollectionURL entered by the user.

### DIFF
--- a/sonar-scm-tfvc-plugin/src/main/java/org/sonar/plugins/scm/tfs/TfsBlameCommand.java
+++ b/sonar-scm-tfvc-plugin/src/main/java/org/sonar/plugins/scm/tfs/TfsBlameCommand.java
@@ -62,6 +62,11 @@ public class TfsBlameCommand extends BlameCommand {
       stdin.write(conf.username() + "\r\n");
       stdin.write(conf.password() + "\r\n");
       stdin.flush();
+
+      stdout.readLine();
+      stdin.write(conf.collectionUri() + "\r\n");
+      stdin.flush();
+
       stdout.readLine();
 
       for (InputFile inputFile : input.filesToBlame()) {
@@ -162,5 +167,4 @@ public class TfsBlameCommand extends BlameCommand {
     }
     return executable;
   }
-
 }

--- a/sonar-scm-tfvc-plugin/src/main/java/org/sonar/plugins/scm/tfs/TfsConfiguration.java
+++ b/sonar-scm-tfvc-plugin/src/main/java/org/sonar/plugins/scm/tfs/TfsConfiguration.java
@@ -24,6 +24,7 @@ public class TfsConfiguration implements BatchComponent {
   private static final String CATEGORY = "TFVC";
   private static final String USERNAME_PROPERTY_KEY = "sonar.tfvc.username";
   private static final String PASSWORD_PROPERTY_KEY = "sonar.tfvc.password.secured";
+  private static final String COLLECTIONURI_PROPERTY_KEY = "sonar.tfvc.collectionuri";
   private final Settings settings;
 
   public TfsConfiguration(Settings settings) {
@@ -49,6 +50,15 @@ public class TfsConfiguration implements BatchComponent {
         .category(CoreProperties.CATEGORY_SCM)
         .subCategory(CATEGORY)
         .index(1)
+        .build(),
+      PropertyDefinition.builder(COLLECTIONURI_PROPERTY_KEY)
+        .name("CollectionURI")
+        .description("Uri of the TFVC collection. Example: - https://[account].visualstudio.com/DefaultCollection or http://ServerName:8080/tfs/DefaultCollection")
+        .type(PropertyType.STRING)
+        .onQualifiers(Qualifiers.PROJECT)
+        .category(CoreProperties.CATEGORY_SCM)
+        .subCategory(CATEGORY)
+        .index(2)
         .build());
   }
 
@@ -58,6 +68,10 @@ public class TfsConfiguration implements BatchComponent {
 
   public String password() {
     return Strings.nullToEmpty(settings.getString(PASSWORD_PROPERTY_KEY));
+  }
+
+  public String collectionUri() {
+    return Strings.nullToEmpty(settings.getString(COLLECTIONURI_PROPERTY_KEY));
   }
 
 }

--- a/sonar-scm-tfvc-plugin/src/test/java/org/sonar/plugins/scm/tfs/TfsConfigurationTest.java
+++ b/sonar-scm-tfvc-plugin/src/test/java/org/sonar/plugins/scm/tfs/TfsConfigurationTest.java
@@ -21,12 +21,16 @@ public class TfsConfigurationTest {
 
     assertThat(config.username()).isEmpty();
     assertThat(config.password()).isEmpty();
+    assertThat(config.collectionUri()).isEmpty();
 
     settings.setProperty("sonar.tfvc.username", "foo");
     assertThat(config.username()).isEqualTo("foo");
 
     settings.setProperty("sonar.tfvc.password.secured", "pwd");
     assertThat(config.password()).isEqualTo("pwd");
+
+    settings.setProperty("sonar.tfvc.collectionuri", "uri");
+    assertThat(config.collectionUri()).isEqualTo("uri");
   }
 
 }

--- a/sonar-scm-tfvc-plugin/src/test/resources/fake.bat
+++ b/sonar-scm-tfvc-plugin/src/test/resources/fake.bat
@@ -1,6 +1,8 @@
 @ECHO OFF
 ECHO Enter credentials
 SET /P user_pass=
+ECHO Enter the Collection URI
+SET /P collectionUri=
 ECHO Enter paths to annotate
 SET /P p=
 ECHO %p%


### PR DESCRIPTION
Allows User to enter the Collection Url for a project and uses it to update the cache.

This resolves the issue pointed out in https://github.com/SonarCommunity/sonar-scm-tfvc/pull/7.