### PR TITLE
SONARTFVC-29  Fix the link to the sources of the plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,9 +27,9 @@
     </license>
   </licenses>
   <scm>
-    <connection>scm:git:git@github.com:SonarCommunity/sonar-tfs.git</connection>
-    <developerConnection>scm:git:git@github.com:SonarCommunity/sonar-tfs.git</developerConnection>
-    <url>https://github.com/SonarCommunity/sonar-tfs</url>
+    <connection>scm:git:git@github.com:SonarCommunity/sonar-scm-tfvc.git</connection>
+    <developerConnection>scm:git:git@github.com:SonarCommunity/sonar-scm-tfvc.git</developerConnection>
+    <url>https://github.com/SonarCommunity/sonar-scm-tfvc</url>
     <tag>HEAD</tag>
   </scm>
 


### PR DESCRIPTION
Fixed the scm provider URLs following the renaming of the project from sonar-tfs to sonar-scm-tfvc